### PR TITLE
feat: 카카오 토큰 만료일, 게임룸 스캔 주기 변경 

### DIFF
--- a/src/main/java/com/example/jungleroyal/common/util/AuthKakaoTokenUtils.java
+++ b/src/main/java/com/example/jungleroyal/common/util/AuthKakaoTokenUtils.java
@@ -42,7 +42,7 @@ public class AuthKakaoTokenUtils {
         log.info("Redirect URI: {}", redirectUri);
     }
 
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;       // 1일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;       // 1일
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 
 

--- a/src/main/java/com/example/jungleroyal/service/GameRoomService.java
+++ b/src/main/java/com/example/jungleroyal/service/GameRoomService.java
@@ -187,7 +187,7 @@ public class GameRoomService {
     /**
      * 1시간마다 currentPlayers가 0이고 RoomStatus가 WAITING인 방을 삭제
      */
-    @Scheduled(fixedRate = 360000) // 1시간 간격
+    @Scheduled(fixedRate = 1000 * 60 * 60) // 1시간 간격
     @Transactional
     public void cleanUpEmptyRooms() {
         log.info("빈 방을 조회중...");


### PR DESCRIPTION
카카오 엑세스 토큰 만료일 변경 : 1시간 -> 1일 

게임룸 스캔 주기 : 1일로 변경