### PR TITLE
feat: 게임룸 대기 중 나가기 로직 구현 및 방 상태 관리

### DIFF
--- a/src/main/java/com/example/jungleroyal/controller/GameController.java
+++ b/src/main/java/com/example/jungleroyal/controller/GameController.java
@@ -7,6 +7,7 @@ import com.example.jungleroyal.common.util.JwtTokenProvider;
 import com.example.jungleroyal.common.util.SecurityUtil;
 import com.example.jungleroyal.domain.game.EndGameRequest;
 import com.example.jungleroyal.domain.game.GameReturnResponse;
+import com.example.jungleroyal.domain.game.LeaveRoomRequest;
 import com.example.jungleroyal.domain.game.StartGameRequest;
 import com.example.jungleroyal.domain.gameroom.GameRoomDto;
 import com.example.jungleroyal.domain.user.UserDto;
@@ -54,6 +55,17 @@ public class GameController {
         gameService.endGame(endGameRequest);
 
         return ResponseEntity.ok("ok");
+    }
+
+    /**
+     * 게임 대기 방에서 유저가 나온 경우 로직 처리
+     *
+     *
+     */
+    @PostMapping("/api/game/leave")
+    public ResponseEntity<String> leave(@RequestBody LeaveRoomRequest leaveRoomRequest) {
+        gameService.leaveRoom(leaveRoomRequest);
+        return ResponseEntity.ok("해당 유저가 방을 나갔습니다.");
     }
 
     /**

--- a/src/main/java/com/example/jungleroyal/domain/game/LeaveRoomRequest.java
+++ b/src/main/java/com/example/jungleroyal/domain/game/LeaveRoomRequest.java
@@ -1,0 +1,11 @@
+package com.example.jungleroyal.domain.game;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LeaveRoomRequest {
+    private String roomId;
+    private String clientId;
+}

--- a/src/main/java/com/example/jungleroyal/infrastructure/UserJpaRepository.java
+++ b/src/main/java/com/example/jungleroyal/infrastructure/UserJpaRepository.java
@@ -15,4 +15,5 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
 
     List<UserJpaEntity> findAllByClientIdIn(List<String> clientIds);
 
+    Optional<UserJpaEntity> findByClientId(String clientId);
 }

--- a/src/main/java/com/example/jungleroyal/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/example/jungleroyal/infrastructure/UserRepositoryImpl.java
@@ -45,4 +45,9 @@ public class UserRepositoryImpl implements UserRepository {
     public void delete(long userId) {
         userJpaRepository.deleteById(userId);
     }
+
+    @Override
+    public Optional<UserJpaEntity> findByClientId(String clientId) {
+        return userJpaRepository.findByClientId(clientId);
+    }
 }

--- a/src/main/java/com/example/jungleroyal/service/repository/UserRepository.java
+++ b/src/main/java/com/example/jungleroyal/service/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository {
     List<UserJpaEntity> findAllByClientIds(List<String> clientIds);
 
     void delete(long userId);
+
+    Optional<UserJpaEntity> findByClientId(String clientId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ jwt:
       - /api/posts/list
       - /api/auth/kakao/login
       - /api/auth/refresh
+      - /api/auth/guest/login
+
+
+scheduler:
+  cleanup:
+    fixed-rate: 1000 * 60 * 60 * 24 # 1일 (1000 * 60 * 60 * 24) 밀리초
 
 logging:
   level:


### PR DESCRIPTION
leaveRoom 메서드 구현:

유저가 대기 중인 방에서 나갈 경우 참여 인원을 감소시키는 로직 추가.
참여 인원이 0명이 되면 방 상태를 END로 설정.
유저 상태 및 연결된 필드를 초기화.
DTO 추가:

LeaveRoomRequest 클래스 생성 (roomId, clientId 필드 포함).

Controller 구현:

/api/rooms/leave 엔드포인트 추가.
요청 바디로 LeaveRoomRequest를 전달받아 로직 실행.